### PR TITLE
Invert rotation

### DIFF
--- a/render.c
+++ b/render.c
@@ -54,7 +54,7 @@ cairo_surface_t *render(struct grim_state *state, struct grim_box *geometry,
 		cairo_matrix_translate(&matrix,
 			(double)output->geometry.width / 2,
 			(double)output->geometry.height / 2);
-		cairo_matrix_rotate(&matrix, get_output_rotation(output->transform));
+		cairo_matrix_rotate(&matrix, -get_output_rotation(output->transform));
 		cairo_matrix_scale(&matrix,
 			(double)raw_output_width / output_width * output_flipped_x,
 			(double)raw_output_height / output_height * output_flipped_y);


### PR DESCRIPTION
Fixes upside down screenshots when the output is rotated 90 or 270 degrees.