### PR TITLE
Fix i686 build -Werror=incompatible-pointer-types complaint

### DIFF
--- a/include/cairo_jpg.h
+++ b/include/cairo_jpg.h
@@ -3,7 +3,7 @@
 
 #include <cairo.h>
 
-cairo_status_t cairo_surface_write_to_jpeg_mem(cairo_surface_t *sfc, unsigned char **data, size_t *len, int quality);
+cairo_status_t cairo_surface_write_to_jpeg_mem(cairo_surface_t *sfc, unsigned char **data, unsigned long *len, int quality);
 cairo_status_t cairo_surface_write_to_jpeg_stream(cairo_surface_t *sfc, cairo_write_func_t write_func, void *closure, int quality);
 cairo_status_t cairo_surface_write_to_jpeg(cairo_surface_t *sfc, const char *filename, int quality);
 


### PR DESCRIPTION
This was caused with jpeg_mem_dest expecting pointer to unsigned long
and being fed with pointer to size_t, which may amount to different
data-width types.  There's also a simple overflow check for such
cases now.

Fixes #28