### PR TITLE
Add example command for grabbing from a specific monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grim
 
-Grab images from a Wayland compositor. Works great with [slurp](https://github.com/emersion/slurp) and [sway](https://github.com/swaywm/sway/) >= 1.0.
+Grab images from a Wayland compositor. Works great with [slurp](https://github.com/emersion/slurp) and also with [sway](https://github.com/swaywm/sway/) >= 1.0.
 
 ## Building
 
@@ -25,6 +25,7 @@ grim -o DP-1 screenshot.png # Screenshoot a specific output
 grim -g "10,20 300x400" screenshot.png # Screenshoot a region
 slurp | grim -g - screenshot.png # Select a region and screenshoot it
 grim $(xdg-user-dir PICTURES)/$(date +'%Y-%m-%d-%H%M%S_grim.png') # Use a timestamped filename
+grim -o $(swaymsg -t get_outputs | grep name | cut -d'"' -f4 | head -1) /tmp/screenshot.png # Grab from a specific monitor, using swaymsg
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ grim -o DP-1 screenshot.png # Screenshoot a specific output
 grim -g "10,20 300x400" screenshot.png # Screenshoot a region
 slurp | grim -g - screenshot.png # Select a region and screenshoot it
 grim $(xdg-user-dir PICTURES)/$(date +'%Y-%m-%d-%H%M%S_grim.png') # Use a timestamped filename
-grim -o $(swaymsg -t get_outputs | grep name | cut -d'"' -f4 | head -1) /tmp/screenshot.png # Grab from a specific monitor, using swaymsg
+grim -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused==true) | .name') /tmp/screenshot.png # Grab a screenshot from the focused monitor
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -11,22 +11,37 @@ Install dependencies:
 
 Then run:
 
-```shell
+```sh
 meson build
 ninja -C build
 build/grim
 ```
 
-## Usage
+## Example Usage
 
-```shell
-grim screenshot.png # Screenshoot all outputs
-grim -o DP-1 screenshot.png # Screenshoot a specific output
-grim -g "10,20 300x400" screenshot.png # Screenshoot a region
-slurp | grim -g - screenshot.png # Select a region and screenshoot it
-grim $(xdg-user-dir PICTURES)/$(date +'%Y-%m-%d-%H%M%S_grim.png') # Use a timestamped filename
-grim -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused==true) | .name') /tmp/screenshot.png # Grab a screenshot from the focused monitor
-```
+Screenshoot all outputs:
+
+    grim screenshot.png
+
+Screenshoot a specific output:
+
+    grim -o DP-1 screenshot.png
+
+Screenshoot a region:
+
+    grim -g "10,20 300x400" screenshot.png
+
+Select a region and screenshoot it:
+
+    slurp | grim -g - screenshot.png
+
+Use a timestamped filename:
+
+    grim $(xdg-user-dir PICTURES)/$(date +'%Y-%m-%d-%H%M%S_grim.png')
+
+Grab a screenshot from the focused monitor under Sway, using `swaymsg` and `jq`:
+
+    grim -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') screenshot.png
 
 ## Installation
 


### PR DESCRIPTION
I have a hotkey bound to this command, in sway:

    grim -o $(swaymsg -t get_outputs | grep name | cut -d'"' -f4 | head -1) /tmp/screenshot.png

This takes a screenshot from one specific monitor.

There are probably even better ways to do this, but this worked for me.

This pull request just adds this command to the list of example commands in the README.