### PR TITLE
Use a default filename if no output filename is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,31 @@ Grab images from a Wayland compositor. Works great with [slurp] and with [sway] 
 Screenshoot all outputs:
 
 ```sh
-grim screenshot.png
+grim
 ```
 
 Screenshoot a specific output:
 
 ```sh
-grim -o DP-1 screenshot.png
+grim -o DP-1
 ```
 
 Screenshoot a region:
 
 ```sh
-grim -g "10,20 300x400" screenshot.png
+grim -g "10,20 300x400"
 ```
 
 Select a region and screenshoot it:
 
 ```sh
-grim -g "$(slurp)" screenshot.png
+grim -g "$(slurp)"
 ```
 
-Use a timestamped filename:
+Use a custom filename:
 
 ```sh
-grim $(xdg-user-dir PICTURES)/$(date +'%Y-%m-%d-%H%M%S_grim.png')
+grim $(xdg-user-dir PICTURES)/$(date +'%s_grim.png')
 ```
 
 Screenshoot and copy to clipboard:
@@ -43,7 +43,7 @@ grim - | wl-copy
 Grab a screenshot from the focused monitor under Sway, using `swaymsg` and `jq`:
 
 ```sh
-grim -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name') screenshot.png
+grim -o $(swaymsg -t get_outputs | jq -r '.[] | select(.focused) | .name')
 ```
 
 ## Installation

--- a/grim.1.scd
+++ b/grim.1.scd
@@ -6,7 +6,7 @@ grim - grab images from a Wayland compositor
 
 # DESCRIPTION
 
-*grim* [options...] <output-file>
+*grim* [options...] [output-file]
 
 # SYNOPSIS
 
@@ -14,8 +14,9 @@ grim is a command-line utility to take screenshots of Wayland desktops. For now
 it requires support for the screencopy protocol to work. Support for the
 xdg-output protocol is optional, but improves fractional scaling support.
 
-grim will write a PNG file to _output-file_. If _output-file_ is *-*, it will
-output the file to the standard output instead.
+grim will write a PNG file to _output-file_, or to a default file name if not
+_output-file_ is not specified. If _output-file_ is *-*, it will output the file
+to the standard output instead.
 
 # OPTIONS
 

--- a/main.c
+++ b/main.c
@@ -221,7 +221,7 @@ void default_filename(char *filename, size_t n, int filetype) {
 }
 
 static const char usage[] =
-	"Usage: grim [options...] <output-file>\n"
+	"Usage: grim [options...] [output-file]\n"
 	"\n"
 	"  -h              Show help message and quit.\n"
 	"  -s <factor>     Set the output image scale factor. Defaults to the\n"


### PR DESCRIPTION
The default filename is an ISO 8601 formatted datetime, followed by "_grim", followed by the extension (for example, `2019-03-17T04:56:02Z_grim.png`). I updated the README so that none of the examples specify a file name except for one which demonstrates how to specify a file name.

Partially resolves #10, however, the screenshot is still always saved in the working directory.