### PR TITLE
Add support for the ppm output format

### DIFF
--- a/cairo_ppm.c
+++ b/cairo_ppm.c
@@ -1,0 +1,96 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cairo.h>
+
+#include "cairo_ppm.h"
+
+cairo_status_t cairo_surface_write_to_ppm_mem(cairo_surface_t *sfc,
+		unsigned char **data, unsigned long *len) {
+	// 256 bytes ought to be enough for everyone
+	char header[256];
+
+	int width = cairo_image_surface_get_width(sfc);
+	int height = cairo_image_surface_get_height(sfc);
+
+	int header_len = snprintf(header, sizeof(header), "P6\n%d %d\n255\n", width, height);
+	assert(header_len <= (int)sizeof(header));
+
+	*len = header_len + width * height * 3;
+	unsigned char *buffer = malloc(*len);
+	*data = buffer;
+
+	// We _do_not_ include the null byte
+	memcpy(buffer, header, header_len);
+	buffer += header_len;
+
+	cairo_format_t cformat = cairo_image_surface_get_format(sfc);
+	assert(cformat == CAIRO_FORMAT_RGB24 || cformat == CAIRO_FORMAT_ARGB32);
+
+	// Both formats are native-endian 32-bit ints
+	uint32_t *pixels = (uint32_t *)cairo_image_surface_get_data(sfc);
+	for (int y = 0; y < height; y++) {
+		for (int x = 0; x < width; x++) {
+			uint32_t p = *pixels++;
+			// RGB order
+			*buffer++ = (p >> 16) & 0xff;
+			*buffer++ = (p >>  8) & 0xff;
+			*buffer++ = (p >>  0) & 0xff;
+		}
+	}
+
+	return CAIRO_STATUS_SUCCESS;
+}
+
+
+static cairo_status_t cj_write(void *closure, const unsigned char *data,
+		unsigned int length) {
+	if (write((long) closure, data, length) < length) {
+		return CAIRO_STATUS_WRITE_ERROR;
+	} else {
+		return CAIRO_STATUS_SUCCESS;
+	}
+}
+
+cairo_status_t cairo_surface_write_to_ppm_stream(cairo_surface_t *sfc,
+		cairo_write_func_t write_func, void *closure) {
+	cairo_status_t e;
+	unsigned char *data = NULL;
+	unsigned long len = 0;
+
+	e = cairo_surface_write_to_ppm_mem(sfc, &data, &len);
+	if (e == CAIRO_STATUS_SUCCESS) {
+		assert(sizeof(unsigned long) <= sizeof(size_t)
+			|| !(len >> (sizeof(size_t) * CHAR_BIT)));
+		e = write_func(closure, data, len);
+		free(data);
+	}
+
+	return e;
+}
+
+cairo_status_t cairo_surface_write_to_ppm(cairo_surface_t *sfc,
+		const char *filename) {
+	cairo_status_t e;
+	int outfile;
+
+	outfile = open(filename,
+		O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+
+	if (outfile == -1) {
+		return CAIRO_STATUS_DEVICE_ERROR;
+	}
+
+	e = cairo_surface_write_to_ppm_stream(sfc, cj_write,
+		(void*) (long) outfile);
+
+	close(outfile);
+	return e;
+}

--- a/include/cairo_ppm.h
+++ b/include/cairo_ppm.h
@@ -1,0 +1,10 @@
+#ifndef _CAIRO_PPM_H
+#define _CAIRO_PPM_H
+
+#include <cairo.h>
+
+cairo_status_t cairo_surface_write_to_ppm_mem(cairo_surface_t *sfc, unsigned char **data, unsigned long *len);
+cairo_status_t cairo_surface_write_to_ppm_stream(cairo_surface_t *sfc, cairo_write_func_t write_func, void *closure);
+cairo_status_t cairo_surface_write_to_ppm(cairo_surface_t *sfc, const char *filename);
+
+#endif

--- a/include/grim.h
+++ b/include/grim.h
@@ -9,6 +9,7 @@
 
 enum grim_filetype {
 	GRIM_FILETYPE_PNG,
+	GRIM_FILETYPE_PPM,
 	GRIM_FILETYPE_JPEG,
 };
 

--- a/main.c
+++ b/main.c
@@ -12,6 +12,7 @@
 #include "grim.h"
 #include "output-layout.h"
 #include "render.h"
+#include "cairo_ppm.h"
 #ifdef HAVE_JPEG
 #include "cairo_jpg.h"
 #endif
@@ -198,7 +199,7 @@ static const char usage[] =
 	"  -s <factor>     Set the output image scale factor. Defaults to the\n"
 	"                  greatest output scale factor.\n"
 	"  -g <geometry>   Set the region to capture.\n"
-	"  -t png|jpeg     Set the output filetype. Defaults to png.\n"
+	"  -t png|ppm|jpeg     Set the output filetype. Defaults to png.\n"
 	"  -q <quality>    Set the JPEG filetype quality 0-100. Defaults to 80.\n"
 	"  -o <output>     Set the output name to capture.\n"
 	"  -c              Include cursors in the screenshot.\n";
@@ -251,6 +252,8 @@ int main(int argc, char *argv[]) {
 		case 't':
 			if (strcmp(optarg, "png") == 0) {
 				output_filetype = GRIM_FILETYPE_PNG;
+			} else if (strcmp(optarg, "ppm") == 0) {
+				output_filetype = GRIM_FILETYPE_PPM;
 			} else if (strcmp(optarg, "jpeg") == 0) {
 #ifdef HAVE_JPEG
 				output_filetype = GRIM_FILETYPE_JPEG;
@@ -411,6 +414,9 @@ int main(int argc, char *argv[]) {
 	cairo_status_t status;
 	if (strcmp(output_filename, "-") == 0) {
 		switch (output_filetype) {
+		case GRIM_FILETYPE_PPM:
+			status = cairo_surface_write_to_png_stream(surface, write_func, stdout);
+			break;
 		case GRIM_FILETYPE_PNG:
 			status = cairo_surface_write_to_png_stream(surface, write_func, stdout);
 			break;
@@ -425,6 +431,9 @@ int main(int argc, char *argv[]) {
 		}
 	} else {
 		switch (output_filetype) {
+		case GRIM_FILETYPE_PPM:
+			status = cairo_surface_write_to_ppm(surface, output_filename);
+			break;
 		case GRIM_FILETYPE_PNG:
 			status = cairo_surface_write_to_png(surface, output_filename);
 			break;

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ grim_files = [
 	'main.c',
 	'output-layout.c',
 	'render.c',
+	'cairo_ppm.c',
 ]
 
 grim_deps = [


### PR DESCRIPTION
This is useful in case grim output is further processed anyway (such as a blurred lockscreen script). PPM does not use any compression and thus creating the output file is significantly faster.

Comparison (3 monitors at 4720 x 1976 combined resolution):

```
$ time grim -t ppm out.ppm
real 0.07
user 0.02
sys 0.01
$ time grim -t png out.png
real 0.73
user 0.68
sys 0.01
```