### PR TITLE
fix: sign-compare warning

### DIFF
--- a/cairo_jpg.c
+++ b/cairo_jpg.c
@@ -82,7 +82,7 @@ cairo_status_t cairo_surface_write_to_jpeg_mem(cairo_surface_t *sfc,
 
 static cairo_status_t cj_write(void *closure, const unsigned char *data,
 		unsigned int length) {
-	if (write((long) closure, data, length) < length) {
+	if (write((long) closure, data, length) < (ssize_t) length) {
 		return CAIRO_STATUS_WRITE_ERROR;
 	} else {
 		return CAIRO_STATUS_SUCCESS;

--- a/cairo_ppm.c
+++ b/cairo_ppm.c
@@ -52,7 +52,7 @@ cairo_status_t cairo_surface_write_to_ppm_mem(cairo_surface_t *sfc,
 
 static cairo_status_t cj_write(void *closure, const unsigned char *data,
 		unsigned int length) {
-	if (write((long) closure, data, length) < length) {
+	if (write((long) closure, data, length) < (ssize_t) length) {
 		return CAIRO_STATUS_WRITE_ERROR;
 	} else {
 		return CAIRO_STATUS_SUCCESS;


### PR DESCRIPTION
there's a sign-compare warning between an unsigned int and signed int(ssize_t) in a couple functions.