### PR TITLE
add missing default

### DIFF
--- a/main.c
+++ b/main.c
@@ -203,7 +203,7 @@ bool default_filename(char *filename, size_t n, int filetype) {
 	}
 
 	char *format_str;
-	const char *ext;
+	const char *ext = NULL;
 	switch (filetype) {
 	case GRIM_FILETYPE_PNG:
 		ext = "png";
@@ -218,10 +218,8 @@ bool default_filename(char *filename, size_t n, int filetype) {
 #else
 		assert(false);
 #endif
-	default:
-		ext = "png";
 	}
-
+	assert(ext != NULL);
 	char tmpstr[32];
 	sprintf(tmpstr, "%%Y%%m%%d_%%Hh%%Mm%%Ss_grim.%s", ext);
 	format_str = tmpstr;

--- a/main.c
+++ b/main.c
@@ -218,6 +218,8 @@ bool default_filename(char *filename, size_t n, int filetype) {
 #else
 		assert(false);
 #endif
+	default:
+		ext = "png";
 	}
 
 	char tmpstr[32];


### PR DESCRIPTION
add default to switch statement in default_filename function

Without that statement ninja complained:
```ninja -C build
ninja: Entering directory `build'
[1/2] Compiling C object 'grim@exe/main.c.o'.
FAILED: grim@exe/main.c.o 
ccache cc -Igrim@exe -I. -I.. -I../include -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/lib/libffi-3.2.1/include -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O3 -Wno-unused-parameter -DHAVE_JPEG -MD -MQ 'grim@exe/main.c.o' -MF 'grim@exe/main.c.o.d' -o 'grim@exe/main.c.o' -c ../main.c
../main.c: In function ‘default_filename’:
../main.c:224:2: error: ‘ext’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  224 |  sprintf(tmpstr, "%%Y%%m%%d_%%Hh%%Mm%%Ss_grim.%s", ext);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.```