### PR TITLE
Define _GNU_SOURCE for strdup()

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
 #include <assert.h>
 #include <cairo.h>
 #include <errno.h>


### PR DESCRIPTION
When uClibc library is used, errors like the following are returned at compile time:
../main.c: In function ‘xdg_output_handle_name’:
../main.c:95:17: error: implicit declaration of function ‘strdup’ [-Werror=implicit-function-declaration]
  output->name = strdup(name);

The strdup() function is available on uClibc if _XOPEN_SOURCE_EXTENDED
is defined. uClibc will set _XOPEN_SOURCE_EXTENDED if _GNU_SOURCE
is set, so let's define it.

Signed-off-by: Gilles Talis <gilles.talis@gmail.com>