### PR TITLE
Correct interpretation of output rotation

### DIFF
--- a/render.c
+++ b/render.c
@@ -104,7 +104,7 @@ cairo_surface_t *render(struct grim_state *state, struct grim_box *geometry,
 		cairo_matrix_translate(&matrix,
 			(double)output->geometry.width / 2,
 			(double)output->geometry.height / 2);
-		cairo_matrix_rotate(&matrix, -get_output_rotation(output->transform));
+		cairo_matrix_rotate(&matrix, get_output_rotation(output->transform));
 		cairo_matrix_scale(&matrix,
 			(double)raw_output_width / output_width * output_flipped_x,
 			(double)raw_output_height / output_height * output_flipped_y);


### PR DESCRIPTION
This fixes grim to treat the rotations as counterclockwise and applied to the surface. This became necessary because wlroots recently corrected its rotation similarly in https://github.com/swaywm/wlroots/pull/2023.

Fixes https://github.com/emersion/grim/issues/71