### PR TITLE
Print better error message when supplied region is invalid

### DIFF
--- a/main.c
+++ b/main.c
@@ -460,7 +460,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (n_pending == 0) {
-		fprintf(stderr, "screenshot region is empty\n");
+		fprintf(stderr, "supplied geometry did not intersect with any outputs\n");
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
From #59:

> This is because your only output is positioned at 0,1080. 10,20 300x400 is outside of those coordinates. We should probably print a better error message.

Changed the error message to hopefully be more clear to the user that the region they supplied did not intersect with any outputs.