### PR TITLE
fix bufferoverflow in output_filepath

### DIFF
--- a/main.c
+++ b/main.c
@@ -371,6 +371,10 @@ int main(int argc, char *argv[]) {
 		filepath(output_filepath, output_filename);
 	} else {
 		output_filename = argv[optind];
+		if (strlen(output_filename) >= PATH_MAX) {
+			fprintf(stderr, "'%s': filepath too long\n", output_filename);
+			return EXIT_FAILURE;
+		}
 		strcpy(output_filepath, output_filename);
 	}
 


### PR DESCRIPTION
Checks that the output filename from argv fits into `char output_filepath[PATH_MAX];` to prevent a stack overflow.
