### PR TITLE
Fix 180-degree rotated buffers without Y_INVERT

### DIFF
--- a/render.c
+++ b/render.c
@@ -104,10 +104,11 @@ cairo_surface_t *render(struct grim_state *state, struct grim_box *geometry,
 		cairo_matrix_translate(&matrix,
 			(double)output->geometry.width / 2,
 			(double)output->geometry.height / 2);
-		cairo_matrix_rotate(&matrix, get_output_rotation(output->transform));
 		cairo_matrix_scale(&matrix,
-			(double)raw_output_width / output_width * output_flipped_x,
+			(double)raw_output_width / output_width,
 			(double)raw_output_height / output_height * output_flipped_y);
+		cairo_matrix_rotate(&matrix, -get_output_rotation(output->transform));
+		cairo_matrix_scale(&matrix, output_flipped_x, 1);
 		cairo_matrix_translate(&matrix,
 			-(double)output_width / 2,
 			-(double)output_height / 2);


### PR DESCRIPTION
When the compositor sends a buffer without the Y_INVERT flag, the
resulting image had it rotated by 180 degrees.

References: https://github.com/swaywm/sway/issues/5818

* * *

Not sure this is the right fix… But I tested this with all combinations of:

- Both the Wayland and DRM backends (right now Wayland with send Y_INVERT, DRM won't)
- Both 90-degree output rotations and flipped 90-degree output rotations