### PR TITLE
add bash completion

### DIFF
--- a/contrib/completions/bash/grim.bash
+++ b/contrib/completions/bash/grim.bash
@@ -1,0 +1,27 @@
+_grim() {
+	_init_completion || return
+
+	CUR="${COMP_WORDS[COMP_CWORD]}"
+	PREV="${COMP_WORDS[COMP_CWORD-1]}"
+
+	if [[ "$PREV" == "-t" ]]; then
+		COMPREPLY=($(compgen -W "png ppm jpeg" -- "$CUR"))
+		return
+	elif [[ "$PREV" == "-o" ]]; then
+		OUTPUTS="$(swaymsg -t get_outputs 2>/dev/null | \
+			jq -r '.[] | select(.active) | "\(.name)\t\(.make) \(.model)"' 2>/dev/null)"
+
+		COMPREPLY=($(compgen -W "$OUTPUTS" -- "$CUR"))
+		return
+	fi
+
+	if [[ "$CUR" == -* ]]; then
+		COMPREPLY=($(compgen -W "-h -s -g -t -q -o -c" -- "$CUR"))
+		return
+	fi
+
+	# fall back to completing filenames
+	_filedir
+}
+
+complete -F _grim grim

--- a/contrib/completions/meson.build
+++ b/contrib/completions/meson.build
@@ -1,7 +1,7 @@
-fish_comp = dependency('fish', required: false)
-
 if get_option('fish-completions')
 	fish_files = files('fish/grim.fish')
+
+	fish_comp = dependency('fish', required: false)
 	if fish_comp.found()
 		fish_install_dir = fish_comp.get_pkgconfig_variable('completionsdir')
 	else
@@ -9,4 +9,12 @@ if get_option('fish-completions')
 		fish_install_dir = join_paths(datadir, 'fish', 'vendor_completions.d')
 	endif
 	install_data(fish_files, install_dir: fish_install_dir)
+endif
+
+
+if get_option('bash-completions')
+	bash_comp = dependency('bash-completion')
+	bash_files = files('bash/grim.bash')
+	bash_install_dir = bash_comp.get_pkgconfig_variable('completionsdir')
+	install_data(bash_files, install_dir: bash_install_dir)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('jpeg', type: 'feature', value: 'auto', description: 'Enable JPEG support')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('fish-completions', type: 'boolean', value: false, description: 'Install fish completions')
+option('bash-completions', type: 'boolean', value: false, description: 'Install bash completions')


### PR DESCRIPTION
Add tab-completion for bash, with the same functionality as the fish completion. I don't really know where to store bash completions scripts if `bash-completion` isn't installed, and since it is a hard dependency at runtime, I wrote the meson script this way.