### PR TITLE
WIP: Read 10-bit buffers and save 16-bit screenshots

### DIFF
--- a/render.c
+++ b/render.c
@@ -52,7 +52,8 @@ static cairo_surface_t *convert_buffer(struct grim_buffer *buffer) {
 			buffer->data, format, buffer->width, buffer->height,
 			buffer->stride);
 	default:
-		fprintf(stderr, "unsupported format %d\n", buffer->format);
+		fprintf(stderr, "unsupported format %d = 0x%08x\n",
+			buffer->format, buffer->format);
 		return NULL;
 	}
 }


### PR DESCRIPTION
This makes it possible to take screenshots when the compositor has >10 bit output. See also issue #95.

Marked WIP, since it requires Cairo >= 1.17.2 to build, and a [bug fix in cairo](https://gitlab.freedesktop.org/cairo/cairo/-/merge_requests/230) to run correctly that will probably only be available when Cairo 1.18.0 is released in a few months. Also, 1.17.2 is a development snapshot, and many distributions are still on the most recent official release, 1.16.0.

To test, modify wlroots to select 10-bit formats for one of the backends; for example, see https://github.com/swaywm/wlroots/commit/2eb44bb8dbe005afc05e259e9f47b402e91975e2 .
