### PR TITLE
render: add support for ≤ 24bpp pixel formats

### DIFF
--- a/render.c
+++ b/render.c
@@ -11,6 +11,34 @@
 
 static pixman_format_code_t get_pixman_format(enum wl_shm_format wl_fmt) {
 	switch (wl_fmt) {
+	case WL_SHM_FORMAT_RGB332:
+		return PIXMAN_r3g3b2;
+	case WL_SHM_FORMAT_BGR233:
+		return PIXMAN_b2g3r3;
+	case WL_SHM_FORMAT_ARGB4444:
+		return PIXMAN_a4r4g4b4;
+	case WL_SHM_FORMAT_XRGB4444:
+		return PIXMAN_x4r4g4b4;
+	case WL_SHM_FORMAT_ABGR4444:
+		return PIXMAN_a4b4g4r4;
+	case WL_SHM_FORMAT_XBGR4444:
+		return PIXMAN_x4b4g4r4;
+	case WL_SHM_FORMAT_ARGB1555:
+		return PIXMAN_a1r5g5b5;
+	case WL_SHM_FORMAT_XRGB1555:
+		return PIXMAN_x1r5g5b5;
+	case WL_SHM_FORMAT_ABGR1555:
+		return PIXMAN_a1b5g5r5;
+	case WL_SHM_FORMAT_XBGR1555:
+		return PIXMAN_x1b5g5r5;
+	case WL_SHM_FORMAT_RGB565:
+		return PIXMAN_r5g6b5;
+	case WL_SHM_FORMAT_BGR565:
+		return PIXMAN_b5g6r5;
+	case WL_SHM_FORMAT_RGB888:
+		return PIXMAN_r8g8b8;
+	case WL_SHM_FORMAT_BGR888:
+		return PIXMAN_b8g8r8;
 	case WL_SHM_FORMAT_ARGB8888:
 		return PIXMAN_a8r8g8b8;
 	case WL_SHM_FORMAT_XRGB8888:


### PR DESCRIPTION
This adds support for the BGR888 pixel format, among others, and thereby should resolve #113 . 

I've added the RGB565 and BGR565 formats because they are likely screenshot pixel formats when the compositor is configured for 16-bit-per-pixel buffers. (RGB565 can be tested with the [mstoeckl/sway/extra-bit-depths](https://github.com/mstoeckl/sway/commits/extra-bit-depths) branch of sway; it is useful in rare cases where the output buffers are sent over a low bandwidth connection.) The remaining formats were added for completeness, and include all the other RGB formats which have both Pixman enum values and DRM fourcc codes.